### PR TITLE
Add AUR instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,14 @@ You can install `lobtui` from [crates.io](https://crates.io/crates/lobtui)
 cargo install lobtui
 ```
 
+## 🐧 Arch Linux
+
+You can install [`lobtui`](https://aur.archlinux.org/packages/lobtui) from the AUR using your favorite [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
+
+```shell
+paru -S lobtui
+```
+
 ### ⚒️ Build from source
 
 Run the following command:


### PR DESCRIPTION
Hey, I packaged `lobtui` for the AUR and this PR simply updates readme to add instructions.

- https://aur.archlinux.org/packages/lobtui
